### PR TITLE
Fixing an error in OS X by explicitly setting certificate verificatio…

### DIFF
--- a/R/getAuth.R
+++ b/R/getAuth.R
@@ -48,7 +48,7 @@ getAuth = function() {
                  'access_type=offline&',
                  'approval_prompt=force', sep='', collapse='')
     cert <- system.file("CurlSSL", "ca-bundle.crt", package = "RCurl")#SSL Certificate Fix for Windows
-    RCurl::getURL(url, cainfo=cert)
+    RCurl::getURL(url, cainfo=cert, ssl.verifypeer = TRUE) # Explicitly setting certificate verification for an error in OS X
     browseURL(url)
     # Manual next-step: input code-parameter to c.token variable and run loadToken()
     cat('Authentication process needs your Client token in order to receive the access token from the API. Copy the Client token from your webbrowser and paste it here.')


### PR DESCRIPTION
Using the function ```doAuth()``` gave the following error when ```RCurl::getURL(url, cainfo=cert)``` is called:

```
Error in function (type, msg, asError = TRUE) : 
SSL: CA certificate set, but certificate verification is disabled
```

Commit in pull request fixes it. Tried on OS X Yosemite 10.10.3, R 3.2.0

R and System information
```
> R.Version()
$platform
[1] "x86_64-apple-darwin13.4.0"

$arch
[1] "x86_64"

$os
[1] "darwin13.4.0"

$system
[1] "x86_64, darwin13.4.0"

$status
[1] ""

$major
[1] "3"

$minor
[1] "2.0"

$year
[1] "2015"

$month
[1] "04"

$day
[1] "16"

$`svn rev`
[1] "68180"

$language
[1] "R"

$version.string
[1] "R version 3.2.0 (2015-04-16)"

$nickname
[1] "Full of Ingredients"


```

RCurl information:
```
> curlVersion()
$age
[1] 3

$version
[1] "7.37.1"

$vesion_num
[1] 468225

$host
[1] "x86_64-apple-darwin14.0"

$features
        ipv6          ssl         libz         ntlm gssnegotiate    asynchdns    largefile 
           1            4            8           16           32          128          512 
     ntlm_wb 
       32768 

$ssl_version
[1] "SecureTransport"

$ssl_version_num
[1] 0

$libz_version
[1] "1.2.5"

$protocols
 [1] "dict"   "file"   "ftp"    "ftps"   "gopher" "http"   "https"  "imap"   "imaps"  "ldap"  
[11] "ldaps"  "pop3"   "pop3s"  "rtsp"   "smtp"   "smtps"  "telnet" "tftp"  

$ares
[1] ""

$ares_num
[1] 0

$libidn
[1] ""
```