### PR TITLE
Move removal of whitespace from field names to changeNames

### DIFF
--- a/R/changeNames.R
+++ b/R/changeNames.R
@@ -8,6 +8,8 @@
 #' 
 #' @return New column names of dataframe.
 changeNames <- function(data){
+  #eliminate " " spaces in column names
+  names(data) <- gsub(" ","",names(data))
   names(data)[names(data)=="Avg.CPC"] <- "CPC"
   names(data)[names(data)=="Avg.position"] <- "Position"
   names(data)[names(data)=="Clickconversionrate"] <- "CVR"

--- a/R/transformData.R
+++ b/R/transformData.R
@@ -103,7 +103,5 @@ transformData <- function(data,
       data[, var] <- data[, var] / 1000000 #convert into micros
     }
   }
-  #eliminate " " spaces in column names
-  names(data) <- gsub(" ","",names(data))
   return(data)
 }


### PR DESCRIPTION
@jburkhardt please review and consider merging.

It seems to me that it makes more sense to remove whitespace from the field names in the changeNames function so that if someone doesn't want the field names to be modified at all then this is possible.