### PR TITLE
use default RCurl SSL

### DIFF
--- a/R/getAuth.R
+++ b/R/getAuth.R
@@ -49,8 +49,10 @@ getAuth = function() {
                  'redirect_uri=urn:ietf:wg:oauth:2.0:oob&',
                  'access_type=offline&',
                  'approval_prompt=force', sep='', collapse='')
-    cert <- system.file("CurlSSL", "ca-bundle.crt", package = "RCurl")#SSL Certificate Fix for Windows
-    RCurl::getURL(url, cainfo=cert, ssl.verifypeer = TRUE) # Explicitly setting certificate verification for an error in OS X
+    #cert <- system.file("CurlSSL", "ca-bundle.crt", package = "RCurl")#SSL Certificate Fix for Windows
+    RCurl::getURL(url,
+                  #cainfo=cert, # Explicitly setting certificate verification for an error in OS X
+                  ssl.verifypeer = TRUE)
     browseURL(url)
     # Manual next-step: input code-parameter to c.token variable and run loadToken()
     cat('Authentication process needs your Client token in order to receive the access token from the API. Copy the Client token from your webbrowser and paste it here.')


### PR DESCRIPTION
During the authentication process with the Adwords API default to standard SSL settings in RCurl.