### PR TITLE
add compression support: gzipped csv data download

### DIFF
--- a/R/statement.R
+++ b/R/statement.R
@@ -10,6 +10,7 @@
 #' CONTAINS | CONTAINS_IGNORE_CASE | DOES_NOT_CONTAIN | DOES_NOT_CONTAIN_IGNORE_CASE
 #' @param start Beginning of date range. Format: 2018-01-01
 #' @param end End of date rage. Format: 2018-01-10
+#' @param compress TRUE / FALSE, Gzipped data download if TRUE
 #' 
 #' @export
 #' @examples
@@ -37,7 +38,8 @@ statement <- function(select = c("AccountDescriptiveName",
                       report = "ACCOUNT_PERFORMANCE_REPORT",
                       where,
                       start = "2018-01-01",
-                      end = "2018-01-10"){  
+                      end = "2018-01-10",
+                      compress = FALSE){  
   # Generates and builds the Adwords Query Language Statement for querying the Adwords API.
   #
   # Args:
@@ -49,26 +51,26 @@ statement <- function(select = c("AccountDescriptiveName",
   #                       CONTAINS | CONTAINS_IGNORE_CASE | DOES_NOT_CONTAIN | DOES_NOT_CONTAIN_IGNORE_CASE
   #   start:  Start date
   #   end:    End date
+  #   compress: TRUE / FALSE, Gzipped data download if TRUE
   #
   # Returns:
   #   The statement for the RCurl post.
   start <- gsub("-", "", start)
   end <- gsub("-", "", end)
   selectA <- paste(select, collapse = ",")
+  fmt <- if(compress) "GZIPPED_CSV" else "CSV"
   if(missing(where)){
-    # body <- paste("__rdquery=SELECT+",selectA,"+FROM+",report,"+DURING+",start,",",end,"&__fmt=CSV",sep='')
-    body <- sprintf("__rdquery=SELECT+%s+FROM+%s+DURING+%s,%s&__fmt=CSV",selectA,report,start,end)
+    body <- sprintf("__rdquery=SELECT+%s+FROM+%s+DURING+%s,%s&__fmt=%s",selectA,report,start,end,fmt)
   }
   if(!missing(where)){
-    # body <- paste("__rdquery=SELECT+",selectA,"+FROM+",report,"+WHERE+",where,"+DURING+",start,",",end,"&__fmt=CSV",sep='')
-    body <- sprintf("__rdquery=SELECT+%s+FROM+%s+WHERE+%s+DURING+%s,%s&__fmt=CSV",selectA,report,where,start,end)
+    body <- sprintf("__rdquery=SELECT+%s+FROM+%s+WHERE+%s+DURING+%s,%s&__fmt=%s",selectA,report,where,start,end,fmt)
   }
   if(report == "LABEL_REPORT"){
-    # body <- paste("__rdquery=SELECT+",selectA,"+FROM+",report,"&__fmt=CSV",sep='')
-    body <- sprintf("__rdquery=SELECT+%s+FROM+%s&__fmt=CSV",selectA,report)
+    body <- sprintf("__rdquery=SELECT+%s+FROM+%s&__fmt=%s",selectA,report,fmt)
     print("The Adwords API does not support date ranges in the Label Report. Thus, date ranges will be ignored in the Label Report")
   }
-  # attach report Type as attributes of body
-  attr(body,"reportType") <- report  
+  # attach report Type and compression as attributes of body
+  attr(body,"reportType") <- report
+  attr(body,"compressed") <- compress
   return(body)
 }

--- a/man/statement.Rd
+++ b/man/statement.Rd
@@ -6,7 +6,7 @@
 \usage{
 statement(select = c("AccountDescriptiveName", "AccountId", "Impressions",
   "Clicks", "Cost", "Date"), report = "ACCOUNT_PERFORMANCE_REPORT", where,
-  start = "2018-01-01", end = "2018-01-10")
+  start = "2018-01-01", end = "2018-01-10", compress = FALSE)
 }
 \arguments{
 \item{select}{Attributes}
@@ -21,6 +21,8 @@ CONTAINS | CONTAINS_IGNORE_CASE | DOES_NOT_CONTAIN | DOES_NOT_CONTAIN_IGNORE_CAS
 \item{start}{Beginning of date range. Format: 2018-01-01}
 
 \item{end}{End of date rage. Format: 2018-01-10}
+
+\item{compress}{TRUE / FALSE, Gzipped data download if TRUE}
 }
 \value{
 The statement neccessary for the \code{\link{getData}} function.


### PR DESCRIPTION
This feature adds the option to download the data from the Adwords API as gzipped csv.  The configuration is handled in ```statement(compress=T)``` . The feature is tested on OS X and Ubuntu Server. The compression reduces the download time of the data extremely. Credits for the developement of the feature go to [@ysgit](https://github.com/ysgit).