### PR TITLE
transforms rawToChar in refreshToken

### DIFF
--- a/R/refreshToken.R
+++ b/R/refreshToken.R
@@ -13,15 +13,18 @@ refreshToken = function(google_auth) {
   #   access.token$refreh_token and credentials as input
   # Returns:
   #   New access.token with corresponding time stamp
-  
-    rt = rjson::fromJSON(RCurl::postForm('https://accounts.google.com/o/oauth2/token', 
+    raw_data = RCurl::postForm('https://accounts.google.com/o/oauth2/token', 
                            refresh_token=google_auth$access$refresh_token, 
                            client_id=google_auth$credentials$c.id,
                            client_secret=google_auth$credentials$c.secret, 
                            grant_type="refresh_token", 
                            style="POST",
-                           .opts = list(ssl.verifypeer = FALSE))) #Fix SSL Certificate problem on Windows
+                           .opts = list(ssl.verifypeer = FALSE)) #Fix SSL Certificate problem on Windows
+    if(is.raw(raw_data)) {
+      rt = rjson::fromJSON(rawToChar(raw_data))
+    } else {
+      rt = rjson::fromJSON(raw_data)
+    }
     access <- rt
-    
     access
 }


### PR DESCRIPTION
Patch for ```refreshToken```:

```RCurl``` returns a raw data file instead of a character file format. ```rjson::fromJSON``` returns an error that is solved with ```rawToChar```.

The error occurred on:
x86_64
VMware Virtual Platform
GNU/Linux
Oracle Linux Server release 7.5