### PR TITLE
new feature: getData() - query multiple accounts from one mcc

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: Aims at loading Google Adwords data into R. Adwords is an online
     R and query the Adwords API with ad-hoc reports. Third, the received data are
     transformed into suitable data formats for further data processing and data
     analysis.
-Version: 0.1.18
+Version: 0.1.19
 Author: Johannes Burkhardt <johannes.burkhardt@gmail.com>, Matthias Bannert
     <matthias.bannert@gmail.com>
 Maintainer: Johannes Burkhardt <johannes.burkhardt@gmail.com>
@@ -19,8 +19,7 @@ Depends:
     R (>= 3.0.0)
 Imports:
     RCurl,
-    rjson,
-    purrr
+    rjson
 Suggests:
     testthat
 License: MIT + file LICENSE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,10 +19,11 @@ Depends:
     R (>= 3.0.0)
 Imports:
     RCurl,
-    rjson
+    rjson,
+    purrr
 Suggests:
     testthat
 License: MIT + file LICENSE
 URL: https://github.com/jburkhardt/RAdwords, https://developers.google.com/adwords, https://developers.google.com/adwords/api/
 BugReports: https://github.com/jburkhardt/RAdwords/issues
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.1

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,14 @@
+RAdwords v0.1.19 (Release Date: 2019-06-24)
+-------------------------------------------
+
+FEATURES
+
+* Supports multiple Google Ads accounts from inside one Google Ads MCC in getData(clientCustomerId = c("xxx-xxx-xxxx", "xxx-xxx-xxxx"))
+
+BUG FIXES
+
+* Forces UTF-8 encoding in readLines (getData(compress = T)) related to issues with special characters on Windows machines.
+
 RAdwords v0.1.18 (Release Date: 2019-01-28)
 -------------------------------------------
 

--- a/R/getData.R
+++ b/R/getData.R
@@ -5,7 +5,7 @@
 #' @description getData posts the Adwords Query Language (awql) Statement which is generated with \code{\link{statement}}.
 #' The data are retrieved from the Adwords API as a dataframe.
 #' 
-#' @param clientCustomerId Adwords Account Id
+#' @param clientCustomerId Adwords Account Id; supports a single account id: "xxx-xxx-xxxx" or a vector of ids from the same Google Ads MCC: c("xxx-xxx-xxxx", "xxx-xxx-xxxx")
 #' @param google_auth list of authentication
 #' @param statement awql statement generated with \code{\link{statement}}.
 #' @param apiVersion supports 201809, 201806, 201802 defaults to 201806.
@@ -14,8 +14,6 @@
 #' @param includeZeroImpressions If TRUE zero impressions will be included. Defaults to FALSE.
 #' @param changeNames If TRUE, the display names of the transformed data are converted into more nicer/practical names. Requires transformation = TRUE
 #' @param verbose Defaults to FALSE. If TRUE, the curl connection output will be printed.
-#' 
-#' @importFrom purrr map
 #' 
 #' @export
 #' 
@@ -28,28 +26,18 @@ getData <- function(clientCustomerId,
                     changeNames=TRUE,
                     includeZeroImpressions=FALSE,
                     verbose=FALSE){
-  if(length(clientCustomerId)==1){
-    data <- .getDataHelper(clientCustomerId = clientCustomerId,
-                           google_auth = google_auth,
-                           statement = statement,
-                           apiVersion = apiVersion,
-                           transformation = transformation,
-                           changeNames = changeNames,
-                           includeZeroImpressions = includeZeroImpressions,
-                           verbose = verbose)
-  } else {
-    data_list <- purrr::map(.x = clientCustomerId,
-                            .f = function(.x){.getDataHelper(clientCustomerId = .x,
-                                                             google_auth = google_auth,
-                                                             statement = statement,
-                                                             apiVersion = apiVersion,
-                                                             transformation = transformation,
-                                                             changeNames = changeNames,
-                                                             includeZeroImpressions = includeZeroImpressions,
-                                                             verbose = verbose)})
-    data <- do.call(rbind, data_list)
-    
-  }
-  
+  # applies .getDataHelper for each account and saves data in list object
+  data_list <- lapply(X = clientCustomerId,
+                      FUN = .getDataHelper,
+                      google_auth = google_auth,
+                      statement = statement,
+                      apiVersion = apiVersion,
+                      transformation = transformation,
+                      changeNames = changeNames,
+                      includeZeroImpressions = includeZeroImpressions,
+                      verbose = verbose)
+  # binds list to dataframe
+  data <- do.call(rbind, data_list)
+  # return
   data
 }

--- a/R/getData.R
+++ b/R/getData.R
@@ -14,7 +14,11 @@
 #' @param includeZeroImpressions If TRUE zero impressions will be included. Defaults to FALSE.
 #' @param changeNames If TRUE, the display names of the transformed data are converted into more nicer/practical names. Requires transformation = TRUE
 #' @param verbose Defaults to FALSE. If TRUE, the curl connection output will be printed.
+#' 
+#' @importFrom purrr map
+#' 
 #' @export
+#' 
 #' @return Dataframe with the Adwords Data.
 getData <- function(clientCustomerId,
                     google_auth,
@@ -24,74 +28,28 @@ getData <- function(clientCustomerId,
                     changeNames=TRUE,
                     includeZeroImpressions=FALSE,
                     verbose=FALSE){
-  
-  # for a better overview split google auth
-  access <- google_auth$access
-  credlist <- google_auth$credentials
-  
-  # because access token can expire 
-  # we need to check whether this is the case
-  if(as.numeric(Sys.time())-3600 >= access$timeStamp){
-    access <- refreshToken(google_auth) 
-  } 
-  # getData posts the Adwords Query Language Statement and retrieves the data.
-  #
-  # Args:
-  #   clientCustomerId: Adwords Account Id
-  #   statement: Object generated with statement() including the Api request.
-  #   transformation: If true, transformData() will be applied on data. Else raw csv data will be returned.
-  # 
-  # Returns:
-  #   Dataframe with the Adwords Data.
-  google.auth <- paste(access$token_type, access$access_token)
-  #cert <- system.file("CurlSSL", "ca-bundle.crt", package = "RCurl")#SSL certification Fix for Windows
-  # data <- RCurl::getURL(paste("https://adwords.google.com/api/adwords/reportdownload/v",apiVersion,sep=""),
-  #                       httpheader = c("Authorization" = google.auth,
-  #                                       "developerToken" = credlist$auth.developerToken,
-  #                                       "clientCustomerId" = clientCustomerId,
-  #                                      "includeZeroImpressions" = includeZeroImpressions),
-  #                postfields=statement,
-  #                verbose = verbose,
-  # #               cainfo = cert, #add SSL certificate
-  #                ssl.verifypeer = TRUE)
-  url <- paste("https://adwords.google.com/api/adwords/reportdownload/v",apiVersion,sep="")
-  header <- c("Authorization" = google.auth,
-              "developerToken" = credlist$auth.developerToken,
-              "clientCustomerId" = clientCustomerId,
-              "includeZeroImpressions" = includeZeroImpressions)
-  if(attributes(statement)$compressed){
-    data <- RCurl::getBinaryURL(url, 
-                                httpheader = header,
-                                postfields=statement,
-                                verbose = verbose,
-    #                           cainfo = cert, #add SSL certificate
-                                ssl.verifypeer = TRUE)
-    tmp <- tempfile()
-    if(.Platform$OS.type == "unix" && file.exists('/dev/shm') && file.info('/dev/shm')$isdir) {
-         tmp <- tempfile(tmpdir = '/dev/shm')
-        }
-        on.exit(unlink(tmp), add = TRUE)
-        writeBin(data, con=tmp)
-        data <- paste(readLines(con <- gzfile(tmp), encoding = "UTF-8"), collapse = "\n")
-        close(con)
+  if(length(clientCustomerId)==1){
+    data <- .getDataHelper(clientCustomerId = clientCustomerId,
+                           google_auth = google_auth,
+                           statement = statement,
+                           apiVersion = apiVersion,
+                           transformation = transformation,
+                           changeNames = changeNames,
+                           includeZeroImpressions = includeZeroImpressions,
+                           verbose = verbose)
   } else {
-    data <- RCurl::getURL(url, 
-                          httpheader = header,
-                          postfields=statement,
-                          verbose = verbose,
-    #                     cainfo = cert, #add SSL certificate
-                          ssl.verifypeer = TRUE)
+    data_list <- purrr::map(.x = clientCustomerId,
+                            .f = function(.x){.getDataHelper(clientCustomerId = .x,
+                                                             google_auth = google_auth,
+                                                             statement = statement,
+                                                             apiVersion = apiVersion,
+                                                             transformation = transformation,
+                                                             changeNames = changeNames,
+                                                             includeZeroImpressions = includeZeroImpressions,
+                                                             verbose = verbose)})
+    data <- do.call(rbind, data_list)
+    
   }
-  # check 
-  valid <- grepl(attr(statement,"reportType"),data)
   
-  if (transformation & valid){
-    data <- transformData(data,
-                          report = attributes(statement)$reportType,
-                          apiVersion = apiVersion)
-    if (changeNames){
-     data <- changeNames(data)
-    }
-  }
-  data  
+  data
 }

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -1,0 +1,81 @@
+.getDataHelper <- function(clientCustomerId,
+                           google_auth,
+                           statement,
+                           apiVersion = "201809",
+                           transformation=TRUE,
+                           changeNames=TRUE,
+                           includeZeroImpressions=FALSE,
+                           verbose=FALSE){
+  
+  # for a better overview split google auth
+  access <- google_auth$access
+  credlist <- google_auth$credentials
+  
+  # because access token can expire 
+  # we need to check whether this is the case
+  if(as.numeric(Sys.time())-3600 >= access$timeStamp){
+    access <- refreshToken(google_auth) 
+  } 
+  # getData posts the Adwords Query Language Statement and retrieves the data.
+  #
+  # Args:
+  #   clientCustomerId: Adwords Account Id
+  #   statement: Object generated with statement() including the Api request.
+  #   transformation: If true, transformData() will be applied on data. Else raw csv data will be returned.
+  # 
+  # Returns:
+  #   Dataframe with the Adwords Data.
+  google.auth <- paste(access$token_type, access$access_token)
+  #cert <- system.file("CurlSSL", "ca-bundle.crt", package = "RCurl")#SSL certification Fix for Windows
+  # data <- RCurl::getURL(paste("https://adwords.google.com/api/adwords/reportdownload/v",apiVersion,sep=""),
+  #                       httpheader = c("Authorization" = google.auth,
+  #                                       "developerToken" = credlist$auth.developerToken,
+  #                                       "clientCustomerId" = clientCustomerId,
+  #                                      "includeZeroImpressions" = includeZeroImpressions),
+  #                postfields=statement,
+  #                verbose = verbose,
+  # #               cainfo = cert, #add SSL certificate
+  #                ssl.verifypeer = TRUE)
+  
+  url <- paste("https://adwords.google.com/api/adwords/reportdownload/v",apiVersion,sep="")
+  header <- c("Authorization" = google.auth,
+              "developerToken" = credlist$auth.developerToken,
+              "clientCustomerId" = clientCustomerId,
+              "includeZeroImpressions" = includeZeroImpressions)
+  if(attributes(statement)$compressed){
+    data <- RCurl::getBinaryURL(url, 
+                                httpheader = header,
+                                postfields=statement,
+                                verbose = verbose,
+                                #                           cainfo = cert, #add SSL certificate
+                                ssl.verifypeer = TRUE)
+    tmp <- tempfile()
+    if(.Platform$OS.type == "unix" && file.exists('/dev/shm') && file.info('/dev/shm')$isdir) {
+      tmp <- tempfile(tmpdir = '/dev/shm')
+    }
+    on.exit(unlink(tmp), add = TRUE)
+    writeBin(data, con=tmp)
+    data <- paste(readLines(con <- gzfile(tmp), encoding = "UTF-8"), collapse = "\n")
+    close(con)
+  } else {
+    data <- RCurl::getURL(url, 
+                          httpheader = header,
+                          postfields=statement,
+                          verbose = verbose,
+                          #                     cainfo = cert, #add SSL certificate
+                          ssl.verifypeer = TRUE)
+  }
+  # check 
+  valid <- grepl(attr(statement,"reportType"),data)
+  
+  if (transformation & valid){
+    data <- transformData(data,
+                          report = attributes(statement)$reportType,
+                          apiVersion = apiVersion)
+    if (changeNames){
+      data <- changeNames(data)
+    }
+  }
+  data 
+  
+}

--- a/man/getData.Rd
+++ b/man/getData.Rd
@@ -11,7 +11,7 @@ getData(clientCustomerId, google_auth, statement, apiVersion = "201809",
   includeZeroImpressions = FALSE, verbose = FALSE)
 }
 \arguments{
-\item{clientCustomerId}{Adwords Account Id}
+\item{clientCustomerId}{Adwords Account Id; supports a single account id: "xxx-xxx-xxxx" or a vector of ids from the same Google Ads MCC: c("xxx-xxx-xxxx", "xxx-xxx-xxxx")}
 
 \item{google_auth}{list of authentication}
 

--- a/man/statement.Rd
+++ b/man/statement.Rd
@@ -4,10 +4,10 @@
 \alias{statement}
 \title{Build Adwords Query Language Statement}
 \usage{
-statement(select = c("AccountDescriptiveName", "AccountId", "Impressions",
-  "Clicks", "Cost", "Date"), report = "ACCOUNT_PERFORMANCE_REPORT", where,
-  start = "2018-01-01", end = "2018-01-10", apiVersion = "201809",
-  compress = TRUE)
+statement(select = c("AccountDescriptiveName", "AccountId",
+  "Impressions", "Clicks", "Cost", "Date"),
+  report = "ACCOUNT_PERFORMANCE_REPORT", where, start = "2018-01-01",
+  end = "2018-01-10", apiVersion = "201809", compress = TRUE)
 }
 \arguments{
 \item{select}{Attributes}


### PR DESCRIPTION
This PR features multiple accounts in ```getData```.
Example Code:
```R
google_auth <- doAuth()

body <- statement(select = c('AccountDescriptiveName','CampaignId', 'CampaignName', 'CampaignStatus'),
                  report = "CAMPAIGN_PERFORMANCE_REPORT",
                  start = "2019-01-01",
                  end = "2019-05-20",compress = T)

test_data <- getData(clientCustomerId=c("***-***-****",  # account id 1
                                                                     "***-***-****"), # account id 2
                     google_auth=google_auth,
                     statement=body)
```
@mbannert I would like to discuss the implementation of this feature. I moved the original code of ```getData``` into R/helpers.R and used ```purrr::map``` inside ```getData```to load data of multiple accounts. In the past, we had a few questions from users about querying multiple accounts. Do you think this makes the package to heavyweight with the dependancy on **purrr**.  Alternatively, we could provide an example code snipped that applies ```purrr::map``` in a run file without incorporating **purrr** into **RAdwords**.